### PR TITLE
Fix code scanning alert no. 3: Reflected cross-site scripting

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.21.1"
+    "express": "^4.21.1",
+    "escape-html": "^1.0.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const app = express();
 const cors = require('cors')
+const escapeHtml = require('escape-html');
 app.use(cors());
 
 let texto = "";
@@ -12,7 +13,7 @@ app.get('/', (req, res) => {
 
 app.get('/grab', (req,res) => {
     const data = req.query.data;
-    texto += data;
+    texto += escapeHtml(data);
     res.send(texto);
 })
 


### PR DESCRIPTION
Fixes [https://github.com/datadiego/datagrab/security/code-scanning/3](https://github.com/datadiego/datagrab/security/code-scanning/3)

To fix the problem, we need to sanitize the user input before incorporating it into the response. The best way to do this is to use a well-known library for escaping HTML, such as `escape-html`. This library will ensure that any potentially dangerous characters in the user input are properly escaped, preventing XSS attacks.

We will:
1. Install the `escape-html` library.
2. Import the `escape-html` library in the `server.js` file.
3. Use the `escape-html` function to sanitize the `data` parameter before appending it to the `texto` variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
